### PR TITLE
Add labels for Traefik reverse proxy.

### DIFF
--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -15,13 +15,6 @@ services:
       - "80"
     deploy:
       labels:
-        # configures the docker flow reverse proxy
-        com.df.notify: "true"
-        com.df.distribute: "true"
-        com.df.servicePath: "/boilerplate/${BUILD_VERSION:?err}/"
-        com.df.reqPathSearch: "/boilerplate/${BUILD_VERSION:?err}/"
-        com.df.reqPathReplace: "/"
-        com.df.port: "80"
         # configures the traefik reverse proxy
         traefik.enable: "true"
         traefik.http.routers.boilerplate-router.rule: "PathPrefix(`/boilerplate/${BUILD_VERSION:?err}`)"

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -15,13 +15,20 @@ services:
       - "80"
     deploy:
       labels:
-        # configures the reverse proxy
+        # configures the docker flow reverse proxy
         com.df.notify: "true"
         com.df.distribute: "true"
         com.df.servicePath: "/boilerplate/${BUILD_VERSION:?err}/"
         com.df.reqPathSearch: "/boilerplate/${BUILD_VERSION:?err}/"
         com.df.reqPathReplace: "/"
         com.df.port: "80"
+        # configures the traefik reverse proxy
+        traefik.enable: "true"
+        traefik.http.routers.boilerplate-router.rule: "PathPrefix(`/boilerplate/${BUILD_VERSION:?err}`)"
+        traefik.http.routers.boilerplate-router.middlewares: "strip-context"
+        traefik.http.middlewares.strip-context.stripprefix.prefixes: "/boilerplate/${BUILD_VERSION:?err}"
+        traefik.http.routers.boilerplate-router.service: "boilerplate-service"
+        traefik.http.services.boilerplate-service.loadbalancer.server.port: "80" 
         # allows Jenkins to kill this stack after the related branch has been deleted
         edu.hawaii.clean-orphaned: "true"
         edu.hawaii.repo: "git@github.com:UniversityOfHawaii/uh-its-boilerplate.git"


### PR DESCRIPTION
I've added the labels for the Traefik load balancer and left the Docker Flow ones in there.  Let me know if you want me to take out the Docker Flow labels.

The current branch is deployed here by the Traefik reverse proxy:
https://doctest.pvt.hawaii.edu/boilerplate/traefik/