### PR TITLE
Add branch specific Traefik labels post-deployment.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     REGISTRY = releaseDataFromGit.registryFromGitStatus()
     BUILD_VERSION = releaseDataFromGit.versionFromGitStatus()
   }
-  
+
   stages {
     stage('Build the image') {
       steps {
@@ -29,6 +29,7 @@ pipeline {
     stage('Deploy the current stack') {
       steps {
         sh "TARGET_ENV=${TARGET_ENV} REGISTRY=${REGISTRY} BUILD_VERSION=${BUILD_VERSION} make deploy"
+        sh "TARGET_ENV=${TARGET_ENV} REGISTRY=${REGISTRY} BUILD_VERSION=${BUILD_VERSION} make add-traefik-labels"
       }
     }
   }

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -17,11 +17,11 @@ services:
       labels:
         # configures the traefik reverse proxy
         traefik.enable: "true"
-        traefik.http.routers.boilerplate-router.rule: "PathPrefix(`/boilerplate/${BUILD_VERSION:?err}`)"
-        traefik.http.routers.boilerplate-router.middlewares: "strip-context"
-        traefik.http.middlewares.strip-context.stripprefix.prefixes: "/boilerplate/${BUILD_VERSION:?err}"
-        traefik.http.routers.boilerplate-router.service: "boilerplate-service"
-        traefik.http.services.boilerplate-service.loadbalancer.server.port: "80" 
+        traefik.http.routers.boilerplate-${BUILD_VERSION:?err}-router.rule: "PathPrefix(`/boilerplate/${BUILD_VERSION:?err}`)"
+        traefik.http.routers.boilerplate-${BUILD_VERSION:?err}-router.middlewares: "boilerplate-${BUILD_VERSION:?err}-middleware1"
+        traefik.http.middlewares.boilerplate-${BUILD_VERSION:?err}-middleware1.stripprefix.prefixes: "/boilerplate/${BUILD_VERSION:?err}"
+        traefik.http.routers.boilerplate-${BUILD_VERSION:?err}-router.service: "boilerplate-${BUILD_VERSION:?err}-service"
+        traefik.http.services.boilerplate-${BUILD_VERSION:?err}-service.loadbalancer.server.port: "80" 
         # allows Jenkins to kill this stack after the related branch has been deleted
         edu.hawaii.clean-orphaned: "true"
         edu.hawaii.repo: "git@github.com:UniversityOfHawaii/uh-its-boilerplate.git"

--- a/docker-compose/test.yml
+++ b/docker-compose/test.yml
@@ -15,17 +15,11 @@ services:
       - "80"
     deploy:
       labels:
-        # configures the traefik reverse proxy
-        traefik.enable: "true"
-        traefik.http.routers.boilerplate-${BUILD_VERSION:?err}-router.rule: "PathPrefix(`/boilerplate/${BUILD_VERSION:?err}`)"
-        traefik.http.routers.boilerplate-${BUILD_VERSION:?err}-router.middlewares: "boilerplate-${BUILD_VERSION:?err}-middleware1"
-        traefik.http.middlewares.boilerplate-${BUILD_VERSION:?err}-middleware1.stripprefix.prefixes: "/boilerplate/${BUILD_VERSION:?err}"
-        traefik.http.routers.boilerplate-${BUILD_VERSION:?err}-router.service: "boilerplate-${BUILD_VERSION:?err}-service"
-        traefik.http.services.boilerplate-${BUILD_VERSION:?err}-service.loadbalancer.server.port: "80" 
         # allows Jenkins to kill this stack after the related branch has been deleted
         edu.hawaii.clean-orphaned: "true"
         edu.hawaii.repo: "git@github.com:UniversityOfHawaii/uh-its-boilerplate.git"
         edu.hawaii.branch: ${BUILD_VERSION:?err}
+        # the traefik reverse proxy labels are added post deployment with the `add-traefik-labels` make target
     networks:
       - proxy
       - default


### PR DESCRIPTION
You can see it worked because both branches are deployed:

https://doctest.pvt.hawaii.edu/boilerplate/master/
https://doctest.pvt.hawaii.edu/boilerplate/traefik/